### PR TITLE
Extend registry settings for storage backends and approximation algor…

### DIFF
--- a/src/collective/vectorsearch/browser/controlpanel.py
+++ b/src/collective/vectorsearch/browser/controlpanel.py
@@ -12,6 +12,7 @@ class VectorSearchControlPanel(RegistryEditForm):
     schema_prefix = "collective.vectorsearch"
     label = _(u"Vector Search Settings")
     description = _(
-        u"Configure embedding models and similarity algorithms for vector search. "
+        u"Configure vector search parameters based on LSH cascade research. "
+        u"See field help text for implementation status and usage guidelines. "
         u"These settings apply to newly created indexes only."
     )

--- a/src/collective/vectorsearch/configure.zcml
+++ b/src/collective/vectorsearch/configure.zcml
@@ -77,4 +77,17 @@
       name="collective.vectorsearch.embedding_models"
   />
 
+  <!-- Register new vocabulary factories for storage backends and algorithms -->
+  <utility
+      component=".vocabularies.StorageBackendsVocabularyFactory"
+      provides="zope.schema.interfaces.IVocabularyFactory"
+      name="collective.vectorsearch.storage_backends"
+  />
+
+  <utility
+      component=".vocabularies.ApproximationAlgorithmsVocabularyFactory"
+      provides="zope.schema.interfaces.IVocabularyFactory"
+      name="collective.vectorsearch.approximation_algorithms"
+  />
+
 </configure>

--- a/src/collective/vectorsearch/embedding.py
+++ b/src/collective/vectorsearch/embedding.py
@@ -6,10 +6,11 @@ class EmbeddingBase:
 
     meta_type = None
 
-    def __init__(self, model, chunk_size=500, prefix_query=None):
+    def __init__(self, model, chunk_size=500, prefix_query=None, prefix_passage=None):
         self.model = model
         self.chunk_size = chunk_size
         self.prefix_query = prefix_query
+        self.prefix_passage = prefix_passage
 
     def embed(self, text: str, query=False) -> np.ndarray:
         raise NotImplementedError
@@ -21,8 +22,12 @@ class SentenceTransformerEmbedding(EmbeddingBase):
     meta_type = "SentenceTransformerEmbedding"
 
     def embed(self, text: str, query=False) -> np.ndarray:
-        if query:
+        # Add appropriate prefix based on query type
+        if query and self.prefix_query:
             text = self.prefix_query + text
+        elif not query and self.prefix_passage:
+            text = self.prefix_passage + text
+
         texts = [
             text[i : i + self.chunk_size] for i in range(0, len(text), self.chunk_size)
         ]
@@ -35,7 +40,7 @@ class FastEmbedEmbedding(EmbeddingBase):
 
     meta_type = "FastEmbedEmbedding"
 
-    def __init__(self, model_name, chunk_size=500, prefix_query=None):
+    def __init__(self, model_name, chunk_size=500, prefix_query=None, prefix_passage=None):
         """
         Initialize FastEmbed embedding.
 
@@ -43,6 +48,7 @@ class FastEmbedEmbedding(EmbeddingBase):
             model_name: Model identifier for FastEmbed (e.g., 'intfloat/e5-base-v2')
             chunk_size: Maximum text length for chunking
             prefix_query: Prefix to add to query text
+            prefix_passage: Prefix to add to passage/document text
         """
         try:
             from fastembed import TextEmbedding
@@ -55,6 +61,7 @@ class FastEmbedEmbedding(EmbeddingBase):
         self.model = TextEmbedding(model_name=model_name)
         self.chunk_size = chunk_size
         self.prefix_query = prefix_query
+        self.prefix_passage = prefix_passage
 
     def embed(self, text: str, query=False) -> np.ndarray:
         """
@@ -62,13 +69,16 @@ class FastEmbedEmbedding(EmbeddingBase):
 
         Args:
             text: Text to embed
-            query: If True, add query prefix
+            query: If True, add query prefix; if False, add passage prefix
 
         Returns:
             numpy array of embeddings
         """
+        # Add appropriate prefix based on query type
         if query and self.prefix_query:
             text = self.prefix_query + text
+        elif not query and self.prefix_passage:
+            text = self.prefix_passage + text
 
         # Chunk text
         texts = [

--- a/src/collective/vectorsearch/interfaces.py
+++ b/src/collective/vectorsearch/interfaces.py
@@ -2,7 +2,7 @@
 """Module where all interfaces, events and exceptions live."""
 
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
-from zope.interface import Interface
+from zope.interface import Interface, invariant, Invalid
 from zope import schema
 from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
 from collective.vectorsearch import _
@@ -27,35 +27,108 @@ class IVectorSearchSettings(Interface):
         required=True,
     )
 
-    embedding_prefix_query = schema.TextLine(
-        title=_(u"Query Prefix"),
-        description=_(
-            u"Prefix to add to query text before embedding. "
-            u"Some models benefit from query-specific prefixes."
-        ),
-        default=u"query: ",
-        required=False,
-    )
-
     embedding_chunk_size = schema.Int(
-        title=_(u"Chunk Size"),
-        description=_(u"Maximum character length for text chunks during embedding."),
+        title=_(u"Text Chunk Size"),
+        description=_(
+            u"Maximum character length for splitting long text into chunks. "
+            u"Long documents are divided into multiple chunks of this size for vectorization. "
+            u"Each chunk is embedded separately."
+        ),
         default=500,
         required=True,
         min=100,
         max=10000,
     )
 
-    similarity_algorithm = schema.Choice(
-        title=_(u"Similarity Algorithm"),
-        description=_(u"Algorithm to use for similarity calculation."),
-        default=u"cosine",
+    storage_backend = schema.Choice(
+        title=_(u"Storage Backend"),
+        description=_(
+            u"Storage system for vector data. "
+            u"BTrees (internal), or external vector databases (FAISS, DuckDB, etc.)"
+        ),
+        vocabulary="collective.vectorsearch.storage_backends",
+        default=u"btrees",
         required=True,
-        vocabulary=SimpleVocabulary([
-            SimpleTerm(value=u"cosine", title=_(u"Cosine Similarity")),
-            # Future: Add more algorithms as they are implemented
-        ]),
     )
+
+    external_db_uri = schema.URI(
+        title=_(u"External Database URI"),
+        description=_(
+            u"URI for external vector database connection. "
+            u"Required when storage backend is not 'btrees'. "
+            u"Examples: 'http://localhost:8080/faiss', 'duckdb:///path/to/db.duckdb'"
+        ),
+        required=False,
+    )
+
+    approximation_algorithm = schema.Choice(
+        title=_(u"Approximation Algorithm"),
+        description=_(
+            u"Search strategy for similarity calculation. "
+            u"Based on LSH cascade research (lsh-cascade-poc). "
+            u"Currently only 'Exhaustive Cosine' is implemented."
+        ),
+        vocabulary="collective.vectorsearch.approximation_algorithms",
+        default=u"exhaustive_cosine",
+        required=True,
+    )
+
+    stage1_retrieval_count = schema.Int(
+        title=_(u"Stage 1: Hamming Distance Pre-filtering"),
+        description=_(
+            u"Number of candidates to retrieve in the first stage using ITQ binary hash Hamming distance. "
+            u"Applied only when using multi-stage ITQ LSH algorithms. "
+            u"Leave empty to skip this stage."
+        ),
+        required=False,
+        min=1,
+        max=100000,
+    )
+
+    stage2_retrieval_count = schema.Int(
+        title=_(u"Stage 2: Cosine Similarity Re-ranking (Top-K)"),
+        description=_(
+            u"Number of top candidates from Stage 1 to re-rank using full cosine similarity. "
+            u"Applied only when using multi-stage ITQ LSH algorithms. "
+            u"Leave empty to skip this stage."
+        ),
+        required=False,
+        min=1,
+        max=100000,
+    )
+
+    stage3_retrieval_count = schema.Int(
+        title=_(u"Stage 3: Final Result Count"),
+        description=_(
+            u"Number of final results to return after all stages. "
+            u"Applied to all algorithms. "
+            u"Leave empty to use system default."
+        ),
+        required=False,
+        min=1,
+        max=10000,
+    )
+
+    pivot_threshold = schema.Int(
+        title=_(u"Pivot Threshold"),
+        description=_(
+            u"Threshold for pivot-based filtering (used in ITQ algorithms). "
+            u"Higher values = more candidates retained. "
+            u"Recommended: 20 (46.2% reduction, 89.8% recall) or 15 (73.9% reduction, 85.9% recall)."
+        ),
+        default=20,
+        required=False,
+        min=1,
+        max=100,
+    )
+
+    @invariant
+    def validate_external_db_uri(obj):
+        """Validate that external_db_uri is provided when storage_backend is not btrees."""
+        if obj.storage_backend != u'btrees' and not obj.external_db_uri:
+            raise Invalid(
+                _(u"External Database URI is required when storage backend is not BTrees.")
+            )
 
 
 class IEmbeddingModelProvider(Interface):
@@ -127,6 +200,18 @@ class IEmbeddingModelProvider(Interface):
         description=_(u"Name of embedding class to use (e.g., SentenceTransformerEmbedding, FastEmbedEmbedding)"),
         default='SentenceTransformerEmbedding',
         required=True,
+    )
+
+    query_prefix = schema.TextLine(
+        title=_(u"Query Prefix"),
+        description=_(u"Prefix to add to query text (e.g., 'query: ' for E5 models). None if not needed."),
+        required=False,
+    )
+
+    passage_prefix = schema.TextLine(
+        title=_(u"Passage Prefix"),
+        description=_(u"Prefix to add to passage/document text (e.g., 'passage: ' for E5 models). None if not needed."),
+        required=False,
     )
 
     def get_embedding_instance(chunk_size=500, prefix_query=None):

--- a/src/collective/vectorsearch/model_providers.py
+++ b/src/collective/vectorsearch/model_providers.py
@@ -26,7 +26,7 @@ class BaseEmbeddingModelProvider:
     available_similarity_methods = ['cosine']
     embedding_class = 'SentenceTransformerEmbedding'  # Default
 
-    def get_embedding_instance(self, chunk_size=500, prefix_query=None):
+    def get_embedding_instance(self, chunk_size=500, prefix_query=None, prefix_passage=None):
         """Factory method - creates appropriate embedding instance based on embedding_class."""
         # Get embedding class
         EmbeddingClass = getattr(emb_module, self.embedding_class)
@@ -35,14 +35,20 @@ class BaseEmbeddingModelProvider:
         if self.embedding_class == 'SentenceTransformerEmbedding':
             cache = ModelCache()
             model = cache.get_model(self.model_name)
-            return EmbeddingClass(model, chunk_size=chunk_size, prefix_query=prefix_query)
+            return EmbeddingClass(
+                model,
+                chunk_size=chunk_size,
+                prefix_query=prefix_query,
+                prefix_passage=prefix_passage
+            )
 
         elif self.embedding_class == 'FastEmbedEmbedding':
             # FastEmbed doesn't use ModelCache (has its own caching)
             return EmbeddingClass(
                 self.model_name,
                 chunk_size=chunk_size,
-                prefix_query=prefix_query
+                prefix_query=prefix_query,
+                prefix_passage=prefix_passage
             )
 
         else:
@@ -68,6 +74,8 @@ class GTESmallProvider(BaseEmbeddingModelProvider):
     itq_boundary_name = 'gte_small_itq'
     available_similarity_methods = ['cosine']  # Phase 1ではcosineのみ
     embedding_class = 'SentenceTransformerEmbedding'
+    query_prefix = None  # GTE does not need prefix
+    passage_prefix = None
 
 
 class E5BaseProvider(BaseEmbeddingModelProvider):
@@ -81,6 +89,8 @@ class E5BaseProvider(BaseEmbeddingModelProvider):
     itq_boundary_name = 'e5_base_itq'
     available_similarity_methods = ['cosine']
     embedding_class = 'SentenceTransformerEmbedding'
+    query_prefix = u'query: '  # E5 requires query prefix
+    passage_prefix = u'passage: '  # E5 requires passage prefix
 
 
 class E5FastEmbedProvider(BaseEmbeddingModelProvider):
@@ -95,3 +105,5 @@ class E5FastEmbedProvider(BaseEmbeddingModelProvider):
     available_similarity_methods = ['cosine']
     embedding_class = 'FastEmbedEmbedding'
     use_cache_dir = True  # FastEmbed uses local model cache
+    query_prefix = u'query: '  # E5 requires query prefix
+    passage_prefix = u'passage: '  # E5 requires passage prefix

--- a/src/collective/vectorsearch/profiles/default/registry/main.xml
+++ b/src/collective/vectorsearch/profiles/default/registry/main.xml
@@ -7,9 +7,11 @@
   <records interface="collective.vectorsearch.interfaces.IVectorSearchSettings"
            prefix="collective.vectorsearch">
     <value key="embedding_model">gte-small</value>
-    <value key="embedding_prefix_query">query: </value>
     <value key="embedding_chunk_size">500</value>
-    <value key="similarity_algorithm">cosine</value>
+    <value key="storage_backend">btrees</value>
+    <value key="external_db_uri"></value>
+    <value key="approximation_algorithm">exhaustive_cosine</value>
+    <value key="pivot_threshold">20</value>
   </records>
 
 </registry>

--- a/src/collective/vectorsearch/vector_index.py
+++ b/src/collective/vectorsearch/vector_index.py
@@ -119,11 +119,10 @@ class VectorIndex(Persistent, Implicit, SimpleItem):
         # Get settings from registry with fallback defaults
         settings = self._get_settings()
 
-        # NEW: Get model provider instead of just model name
+        # Get model provider instead of just model name
         model_id = settings.get('embedding_model', 'gte-small')
-        prefix_query = settings.get('embedding_prefix_query', 'query: ')
         chunk_size = settings.get('embedding_chunk_size', 500)
-        similarity_algo = settings.get('similarity_algorithm', 'cosine')
+        approx_algo = settings.get('approximation_algorithm', 'exhaustive_cosine')
 
         # Get model provider utility
         model_provider = queryUtility(IEmbeddingModelProvider, name=model_id)
@@ -136,59 +135,117 @@ class VectorIndex(Persistent, Implicit, SimpleItem):
         # Store provider for later use
         self.model_provider = model_provider
 
+        # Get prefixes from model provider (not from settings)
+        prefix_query = getattr(model_provider, 'query_prefix', None)
+        prefix_passage = getattr(model_provider, 'passage_prefix', None)
+
         # Get embedding instance from provider
         self.embedding = model_provider.get_embedding_instance(
             chunk_size=chunk_size,
-            prefix_query=prefix_query
+            prefix_query=prefix_query,
+            prefix_passage=prefix_passage
         )
 
-        # Load ITQ data if available and needed (Phase 1: not implemented)
-        if similarity_algo == 'itq_hamming':
+        # Load ITQ data if available and needed (Phase 2: not implemented yet)
+        if approx_algo in ('itq_lsh_2stage', 'itq_lsh_3stage'):
             self.itq_boundary = model_provider.get_itq_boundary()
             self.pivot_data = model_provider.get_pivot_data()
         else:
             self.itq_boundary = None
             self.pivot_data = None
 
-        # Initialize similarity algorithm
-        if similarity_algo == 'cosine':
+        # Initialize similarity algorithm (Phase 1: only cosine implemented)
+        if approx_algo == 'exhaustive_cosine':
             self.similarity_algorithm = CosineSimilarityAlgorithm()
         else:
-            # Default to cosine for now
+            # Default to cosine for now (other algorithms not implemented)
             self.similarity_algorithm = CosineSimilarityAlgorithm()
 
     def _get_settings(self):
-        """Get settings from registry with error handling and fallback defaults."""
+        """Retrieve all configuration from registry."""
         try:
             registry = api.portal.get_registry_record
-            return {
+
+            settings = {
                 'embedding_model': registry(
                     'collective.vectorsearch.embedding_model',
                     default='gte-small'
-                ),
-                'embedding_prefix_query': registry(
-                    'collective.vectorsearch.embedding_prefix_query',
-                    default='query: '
                 ),
                 'embedding_chunk_size': registry(
                     'collective.vectorsearch.embedding_chunk_size',
                     default=500
                 ),
-                'similarity_algorithm': registry(
-                    'collective.vectorsearch.similarity_algorithm',
-                    default='cosine'
+                'storage_backend': registry(
+                    'collective.vectorsearch.storage_backend',
+                    default='btrees'
+                ),
+                'external_db_uri': registry(
+                    'collective.vectorsearch.external_db_uri',
+                    default=''
+                ),
+                'approximation_algorithm': registry(
+                    'collective.vectorsearch.approximation_algorithm',
+                    default='exhaustive_cosine'
+                ),
+                'stage1_retrieval_count': registry(
+                    'collective.vectorsearch.stage1_retrieval_count',
+                    default=None
+                ),
+                'stage2_retrieval_count': registry(
+                    'collective.vectorsearch.stage2_retrieval_count',
+                    default=None
+                ),
+                'stage3_retrieval_count': registry(
+                    'collective.vectorsearch.stage3_retrieval_count',
+                    default=None
+                ),
+                'pivot_threshold': registry(
+                    'collective.vectorsearch.pivot_threshold',
+                    default=20
                 ),
             }
+
+            # Log current implementation status
+            self._log_implementation_status(settings)
+
+            return settings
+
         except Exception as e:
+            logger.warning(f"Could not read registry: {e}")
+            return self._get_default_settings()
+
+    def _log_implementation_status(self, settings):
+        """Log warnings for features not yet implemented."""
+
+        # Storage backend implementation status
+        implemented_backends = ['btrees']
+        if settings['storage_backend'] not in implemented_backends:
             logger.warning(
-                f"Could not read registry settings: {e}. Using defaults."
+                f"Storage backend '{settings['storage_backend']}' is not yet implemented. "
+                f"Current implementation: {', '.join(implemented_backends)}"
             )
-            return {
-                'embedding_model': 'gte-small',
-                'embedding_prefix_query': 'query: ',
-                'embedding_chunk_size': 500,
-                'similarity_algorithm': 'cosine',
-            }
+
+        # Approximation algorithm implementation status
+        implemented_algorithms = ['exhaustive_cosine']
+        if settings['approximation_algorithm'] not in implemented_algorithms:
+            logger.warning(
+                f"Approximation algorithm '{settings['approximation_algorithm']}' is not yet implemented. "
+                f"Current implementation: {', '.join(implemented_algorithms)}"
+            )
+
+    def _get_default_settings(self):
+        """Fallback default settings."""
+        return {
+            'embedding_model': 'gte-small',
+            'embedding_chunk_size': 500,
+            'storage_backend': 'btrees',
+            'external_db_uri': '',
+            'approximation_algorithm': 'exhaustive_cosine',
+            'stage1_retrieval_count': None,
+            'stage2_retrieval_count': None,
+            'stage3_retrieval_count': None,
+            'pivot_threshold': 20,
+        }
 
     def _change_length(self, name, value):
         length_obj = getattr(self, name, None)

--- a/src/collective/vectorsearch/vocabularies.py
+++ b/src/collective/vectorsearch/vocabularies.py
@@ -49,3 +49,67 @@ class EmbeddingModelsVocabulary:
 
 # Create singleton instance
 EmbeddingModelsVocabularyFactory = EmbeddingModelsVocabulary()
+
+
+@provider(IVocabularyFactory)
+class StorageBackendsVocabulary:
+    """Vocabulary for storage backend options."""
+
+    def __call__(self, context):
+        return SimpleVocabulary([
+            SimpleTerm(
+                value=u'btrees',
+                token=u'btrees',
+                title=u'BTrees (Internal)'
+            ),
+            SimpleTerm(
+                value=u'faiss',
+                token=u'faiss',
+                title=u'FAISS'
+            ),
+            SimpleTerm(
+                value=u'duckdb',
+                token=u'duckdb',
+                title=u'DuckDB'
+            ),
+            SimpleTerm(
+                value=u'annoy',
+                token=u'annoy',
+                title=u'Annoy'
+            ),
+        ])
+
+
+StorageBackendsVocabularyFactory = StorageBackendsVocabulary()
+
+
+@provider(IVocabularyFactory)
+class ApproximationAlgorithmsVocabulary:
+    """Vocabulary for approximation algorithm options."""
+
+    def __call__(self, context):
+        return SimpleVocabulary([
+            SimpleTerm(
+                value=u'exhaustive_cosine',
+                token=u'exhaustive_cosine',
+                title=u'Exhaustive Cosine Search'
+            ),
+            SimpleTerm(
+                value=u'hnsw',
+                token=u'hnsw',
+                title=u'HNSW'
+            ),
+            SimpleTerm(
+                value=u'itq_lsh_2stage',
+                token=u'itq_lsh_2stage',
+                title=u'ITQ LSH 2-stage'
+            ),
+            SimpleTerm(
+                value=u'itq_lsh_3stage',
+                token=u'itq_lsh_3stage',
+                title=u'ITQ LSH 3-stage'
+            ),
+        ])
+
+
+ApproximationAlgorithmsVocabularyFactory = ApproximationAlgorithmsVocabulary()


### PR DESCRIPTION
refs # 12

## Summary

- Extend `IVectorSearchSettings` to support future vector search features based on LSH cascade research
- Add storage backend configuration (BTrees, FAISS, DuckDB, Annoy)
- Add approximation algorithm options (Exhaustive Cosine, HNSW, ITQ LSH 2/3-stage)
- Add multi-stage retrieval count settings for ITQ algorithms
- Move query/passage prefix handling from global settings to model providers
- Add vocabularies for new Choice fields

## Changes

### interfaces.py
- Remove `embedding_prefix_query` and `similarity_algorithm`
- Add `storage_backend`, `external_db_uri`, `approximation_algorithm`
- Add `stage1/2/3_retrieval_count` and `pivot_threshold` for ITQ
- Add `query_prefix` and `passage_prefix` to `IEmbeddingModelProvider`
- Add invariant validation for external DB URI

### embedding.py / model_providers.py
- Support `prefix_passage` in embedding classes
- Add prefix attributes to model providers (E5 uses prefixes, GTE does not)

### vector_index.py
- Update `_get_settings()` for new schema
- Add implementation status logging for unimplemented features

### vocabularies.py / configure.zcml
- Add `StorageBackendsVocabulary` and `ApproximationAlgorithmsVocabulary`

## Implementation Status

Currently implemented:
- ✅ BTrees storage backend
- ✅ Exhaustive Cosine search

Future implementation:
- ⏳ FAISS, DuckDB, Annoy backends
- ⏳ HNSW, ITQ LSH algorithms

## Test plan

- [x] Verify control panel displays new fields correctly
- [x] Verify registry records are created with default values
- [x] Verify unimplemented feature warnings are logged app