### PR TITLE
Mark unimplemented options as unavailable in control panel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,11 @@ Features:
 
   [terapyon]
 
+- Mark unimplemented options as "(not yet available)" in control panel vocabularies
+  (storage backends: FAISS, DuckDB, Annoy; approximation algorithm: HNSW).
+  Add interface invariants to prevent saving unimplemented options.
+  [terapyon]
+
 
 1.0a1 (unreleased)
 ------------------

--- a/src/collective/vectorsearch/interfaces.py
+++ b/src/collective/vectorsearch/interfaces.py
@@ -49,7 +49,8 @@ class IVectorSearchSettings(Interface):
         title=_("Storage Backend"),
         description=_(
             "Storage system for vector data. "
-            "BTrees (internal), or external vector databases (FAISS, DuckDB, etc.)"
+            "Currently only BTrees (internal) is available. "
+            "External vector databases (FAISS, DuckDB, etc.) are planned for future releases."
         ),
         vocabulary="collective.vectorsearch.storage_backends",
         default="btrees",
@@ -59,9 +60,8 @@ class IVectorSearchSettings(Interface):
     external_db_uri = schema.URI(
         title=_("External Database URI"),
         description=_(
-            "URI for external vector database connection. "
-            "Required when storage backend is not 'btrees'. "
-            "Examples: 'http://localhost:8080/faiss', 'duckdb:///path/to/db.duckdb'"
+            "URI for external vector database connection (not yet available). "
+            "This setting will be used when external storage backends are implemented."
         ),
         required=False,
     )
@@ -71,7 +71,7 @@ class IVectorSearchSettings(Interface):
         description=_(
             "Search strategy for similarity calculation. "
             "Based on LSH cascade research (lsh-cascade-poc). "
-            "Currently only 'Exhaustive Cosine' is implemented."
+            "Available: Exhaustive Cosine, ITQ LSH 2-stage, ITQ LSH 3-stage."
         ),
         vocabulary="collective.vectorsearch.approximation_algorithms",
         default="exhaustive_cosine",
@@ -106,12 +106,42 @@ class IVectorSearchSettings(Interface):
     )
 
     @invariant
+    def validate_storage_backend(obj):
+        """Validate that only implemented storage backends can be selected."""
+        implemented_backends = ["btrees"]
+        if obj.storage_backend not in implemented_backends:
+            raise Invalid(
+                _(
+                    "Storage backend '${backend}' is not yet available. "
+                    "Currently only BTrees is supported.",
+                    mapping={"backend": obj.storage_backend},
+                )
+            )
+
+    @invariant
     def validate_external_db_uri(obj):
         """Validate that external_db_uri is provided when storage_backend is not btrees."""
         if obj.storage_backend != "btrees" and not obj.external_db_uri:
             raise Invalid(
                 _(
                     "External Database URI is required when storage backend is not BTrees."
+                )
+            )
+
+    @invariant
+    def validate_approximation_algorithm(obj):
+        """Validate that only implemented approximation algorithms can be selected."""
+        implemented_algorithms = [
+            "exhaustive_cosine",
+            "itq_lsh_2stage",
+            "itq_lsh_3stage",
+        ]
+        if obj.approximation_algorithm not in implemented_algorithms:
+            raise Invalid(
+                _(
+                    "Approximation algorithm '${algorithm}' is not yet available. "
+                    "Currently supported: Exhaustive Cosine, ITQ LSH 2-stage, ITQ LSH 3-stage.",
+                    mapping={"algorithm": obj.approximation_algorithm},
                 )
             )
 

--- a/src/collective/vectorsearch/tests/test_vocabularies.py
+++ b/src/collective/vectorsearch/tests/test_vocabularies.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""Vocabulary and interface invariant tests for this package."""
+
+import unittest
+
+from zope.interface import Invalid
+
+
+class TestStorageBackendsVocabulary(unittest.TestCase):
+    """Test StorageBackendsVocabulary labels."""
+
+    def test_btrees_is_available(self):
+        """Test that BTrees has no 'not yet available' label."""
+        from collective.vectorsearch.vocabularies import StorageBackendsVocabulary
+
+        vocab = StorageBackendsVocabulary()(None)
+        term = vocab.getTermByToken("btrees")
+        self.assertEqual(term.title, "BTrees (Internal)")
+        self.assertNotIn("not yet available", term.title)
+
+    def test_faiss_not_yet_available(self):
+        """Test that FAISS is labeled as not yet available."""
+        from collective.vectorsearch.vocabularies import StorageBackendsVocabulary
+
+        vocab = StorageBackendsVocabulary()(None)
+        term = vocab.getTermByToken("faiss")
+        self.assertIn("not yet available", term.title)
+
+    def test_duckdb_not_yet_available(self):
+        """Test that DuckDB is labeled as not yet available."""
+        from collective.vectorsearch.vocabularies import StorageBackendsVocabulary
+
+        vocab = StorageBackendsVocabulary()(None)
+        term = vocab.getTermByToken("duckdb")
+        self.assertIn("not yet available", term.title)
+
+    def test_annoy_not_yet_available(self):
+        """Test that Annoy is labeled as not yet available."""
+        from collective.vectorsearch.vocabularies import StorageBackendsVocabulary
+
+        vocab = StorageBackendsVocabulary()(None)
+        term = vocab.getTermByToken("annoy")
+        self.assertIn("not yet available", term.title)
+
+
+class TestApproximationAlgorithmsVocabulary(unittest.TestCase):
+    """Test ApproximationAlgorithmsVocabulary labels."""
+
+    def test_exhaustive_cosine_is_available(self):
+        """Test that Exhaustive Cosine has no 'not yet available' label."""
+        from collective.vectorsearch.vocabularies import (
+            ApproximationAlgorithmsVocabulary,
+        )
+
+        vocab = ApproximationAlgorithmsVocabulary()(None)
+        term = vocab.getTermByToken("exhaustive_cosine")
+        self.assertNotIn("not yet available", term.title)
+
+    def test_itq_lsh_2stage_is_available(self):
+        """Test that ITQ LSH 2-stage has no 'not yet available' label."""
+        from collective.vectorsearch.vocabularies import (
+            ApproximationAlgorithmsVocabulary,
+        )
+
+        vocab = ApproximationAlgorithmsVocabulary()(None)
+        term = vocab.getTermByToken("itq_lsh_2stage")
+        self.assertNotIn("not yet available", term.title)
+
+    def test_itq_lsh_3stage_is_available(self):
+        """Test that ITQ LSH 3-stage has no 'not yet available' label."""
+        from collective.vectorsearch.vocabularies import (
+            ApproximationAlgorithmsVocabulary,
+        )
+
+        vocab = ApproximationAlgorithmsVocabulary()(None)
+        term = vocab.getTermByToken("itq_lsh_3stage")
+        self.assertNotIn("not yet available", term.title)
+
+    def test_hnsw_not_yet_available(self):
+        """Test that HNSW is labeled as not yet available."""
+        from collective.vectorsearch.vocabularies import (
+            ApproximationAlgorithmsVocabulary,
+        )
+
+        vocab = ApproximationAlgorithmsVocabulary()(None)
+        term = vocab.getTermByToken("hnsw")
+        self.assertIn("not yet available", term.title)
+
+
+class TestSettingsInvariants(unittest.TestCase):
+    """Test IVectorSearchSettings invariant validation."""
+
+    def _make_settings(self, **kwargs):
+        """Create a mock settings object for invariant testing."""
+
+        class MockSettings:
+            storage_backend = kwargs.get("storage_backend", "btrees")
+            external_db_uri = kwargs.get("external_db_uri", "")
+            approximation_algorithm = kwargs.get(
+                "approximation_algorithm", "exhaustive_cosine"
+            )
+
+        return MockSettings()
+
+    def test_btrees_backend_is_valid(self):
+        """Test that btrees backend passes validation."""
+        from collective.vectorsearch.interfaces import IVectorSearchSettings
+
+        settings = self._make_settings(storage_backend="btrees")
+        # Should not raise
+        IVectorSearchSettings.validateInvariants(settings)
+
+    def test_faiss_backend_is_rejected(self):
+        """Test that faiss backend is rejected by invariant."""
+        from collective.vectorsearch.interfaces import IVectorSearchSettings
+
+        settings = self._make_settings(
+            storage_backend="faiss", external_db_uri="http://example.com/faiss"
+        )
+        with self.assertRaises(Invalid):
+            IVectorSearchSettings.validateInvariants(settings)
+
+    def test_duckdb_backend_is_rejected(self):
+        """Test that duckdb backend is rejected by invariant."""
+        from collective.vectorsearch.interfaces import IVectorSearchSettings
+
+        settings = self._make_settings(
+            storage_backend="duckdb",
+            external_db_uri="duckdb:///path/to/db.duckdb",
+        )
+        with self.assertRaises(Invalid):
+            IVectorSearchSettings.validateInvariants(settings)
+
+    def test_exhaustive_cosine_is_valid(self):
+        """Test that exhaustive_cosine algorithm passes validation."""
+        from collective.vectorsearch.interfaces import IVectorSearchSettings
+
+        settings = self._make_settings(approximation_algorithm="exhaustive_cosine")
+        # Should not raise
+        IVectorSearchSettings.validateInvariants(settings)
+
+    def test_itq_lsh_2stage_is_valid(self):
+        """Test that itq_lsh_2stage algorithm passes validation."""
+        from collective.vectorsearch.interfaces import IVectorSearchSettings
+
+        settings = self._make_settings(approximation_algorithm="itq_lsh_2stage")
+        # Should not raise
+        IVectorSearchSettings.validateInvariants(settings)
+
+    def test_itq_lsh_3stage_is_valid(self):
+        """Test that itq_lsh_3stage algorithm passes validation."""
+        from collective.vectorsearch.interfaces import IVectorSearchSettings
+
+        settings = self._make_settings(approximation_algorithm="itq_lsh_3stage")
+        # Should not raise
+        IVectorSearchSettings.validateInvariants(settings)
+
+    def test_hnsw_algorithm_is_rejected(self):
+        """Test that hnsw algorithm is rejected by invariant."""
+        from collective.vectorsearch.interfaces import IVectorSearchSettings
+
+        settings = self._make_settings(approximation_algorithm="hnsw")
+        with self.assertRaises(Invalid):
+            IVectorSearchSettings.validateInvariants(settings)

--- a/src/collective/vectorsearch/vocabularies.py
+++ b/src/collective/vectorsearch/vocabularies.py
@@ -116,9 +116,21 @@ class StorageBackendsVocabulary:
         return SimpleVocabulary(
             [
                 SimpleTerm(value="btrees", token="btrees", title="BTrees (Internal)"),
-                SimpleTerm(value="faiss", token="faiss", title="FAISS"),
-                SimpleTerm(value="duckdb", token="duckdb", title="DuckDB"),
-                SimpleTerm(value="annoy", token="annoy", title="Annoy"),
+                SimpleTerm(
+                    value="faiss",
+                    token="faiss",
+                    title="FAISS (not yet available)",
+                ),
+                SimpleTerm(
+                    value="duckdb",
+                    token="duckdb",
+                    title="DuckDB (not yet available)",
+                ),
+                SimpleTerm(
+                    value="annoy",
+                    token="annoy",
+                    title="Annoy (not yet available)",
+                ),
             ]
         )
 
@@ -138,7 +150,11 @@ class ApproximationAlgorithmsVocabulary:
                     token="exhaustive_cosine",
                     title="Exhaustive Cosine Search",
                 ),
-                SimpleTerm(value="hnsw", token="hnsw", title="HNSW"),
+                SimpleTerm(
+                    value="hnsw",
+                    token="hnsw",
+                    title="HNSW (not yet available)",
+                ),
                 SimpleTerm(
                     value="itq_lsh_2stage",
                     token="itq_lsh_2stage",


### PR DESCRIPTION
## Summary
- Mark unimplemented storage backends (FAISS, DuckDB, Annoy) and approximation
  algorithm (HNSW) as "(not yet available)" in control panel dropdowns
- Add interface invariants to reject unimplemented options on save
- Update README.rst (English) and README-ja.rst (Japanese) with multi-stage
  search architecture, configuration details, and pip install instructions
- Update CHANGES.rst with full changelog for 1.0a1 and 1.0a2
- Bump version to 1.0a2