### PR TITLE
Fix FastEmbed model cache not persisting across restarts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,21 @@ Changelog
 =========
 
 
+1.0a5 (unreleased)
+------------------
+
+Bug fixes:
+
+- Pass ``cache_dir`` and ``local_files_only`` to FastEmbed ``TextEmbedding``.
+  Previously, ``FastEmbedEmbedding`` did not forward these parameters, so the
+  cache location was entirely dependent on the ``FASTEMBED_CACHE_PATH``
+  environment variable at runtime. Model loading now tries local cache first
+  (``local_files_only=True``) and falls back to network download, matching the
+  existing ``ModelCache.get_model()`` behavior for Sentence Transformers.
+  This also activates the previously unused ``use_cache_dir`` provider attribute.
+  [terapyon]
+
+
 1.0a4 (unreleased)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Changelog
 
 Bug fixes:
 
+- Fix ``vectorsearch-download`` CLI failing for custom models
+  (e.g., ``intfloat/multilingual-e5-base``) that are not in FastEmbed's
+  built-in supported list. The download command now registers custom models
+  via ``_register_fastembed_custom_model()`` before attempting download.
+  [terapyon]
+
 - Pass ``cache_dir`` and ``local_files_only`` to FastEmbed ``TextEmbedding``.
   Previously, ``FastEmbedEmbedding`` did not forward these parameters, so the
   cache location was entirely dependent on the ``FASTEMBED_CACHE_PATH``

--- a/README-ja.rst
+++ b/README-ja.rst
@@ -246,16 +246,43 @@ ZMIから追加のVectorIndexインスタンスを作成できます:
     />
 
 
+モデルキャッシュディレクトリ
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+デフォルトでは、FastEmbedはモデルファイルを ``~/.cache/fastembed`` に保存します。
+``FASTEMBED_CACHE_PATH`` 環境変数を設定して永続的な場所を指定できます。
+
+buildoutの場合（instanceセクションの ``environment-vars``）::
+
+    [instance]
+    recipe = plone.recipe.zope2instance
+    environment-vars =
+        FASTEMBED_CACHE_PATH ${buildout:directory}/var/fastembed_cache
+
+起動スクリプトや ``.env`` ファイルの場合::
+
+    export FASTEMBED_CACHE_PATH=/var/plone/fastembed_cache
+
+**重要:** 一部の環境（例: tmpfsを使用するDocker）では、キャッシュがデフォルトで ``/tmp`` に
+配置される場合があります。 ``/tmp`` は再起動時にクリアされるため、 ``FASTEMBED_CACHE_PATH``
+を永続的なディレクトリに設定することで、再起動後のモデルファイル消失を防げます。
+
+起動時、パッケージはまずネットワークアクセスなしでローカルキャッシュからモデルの読み込みを
+試みます。ローカルキャッシュが利用できない場合は、HuggingFace Hubからのダウンロードに
+フォールバックします。これにより、モデルがダウンロード済みであればシステムは完全にオフラインで
+動作します。
+
 オフラインモデルダウンロード
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-FastEmbedは初回使用時にモデルをダウンロードします。オフライン環境では、
-CLIコマンドを使用してモデルを事前にダウンロードできます::
+FastEmbedは初回使用時にモデルをダウンロードします。オフライン環境や本番環境では、
+CLIコマンドを使用してキャッシュディレクトリにモデルを事前にダウンロードできます::
 
+    # キャッシュディレクトリを設定（省略時は ~/.cache/fastembed）
+    export FASTEMBED_CACHE_PATH=/var/plone/fastembed_cache
+
+    # サポートされているすべてのモデルをキャッシュディレクトリにダウンロード
     vectorsearch-download
-
-これにより、サポートされているすべてのモデルが ``~/.cache/fastembed`` にダウンロードされます。
-別の場所を使用するには ``FASTEMBED_CACHE_PATH`` 環境変数を設定してください。
 
 
 重要な注意事項

--- a/README.rst
+++ b/README.rst
@@ -247,16 +247,43 @@ Register it in your package's ``configure.zcml``::
     />
 
 
+Model Cache Directory
+~~~~~~~~~~~~~~~~~~~~~
+
+By default, FastEmbed stores model files in ``~/.cache/fastembed``.
+Set the ``FASTEMBED_CACHE_PATH`` environment variable to use a persistent location.
+
+In buildout (``environment-vars`` in the instance section)::
+
+    [instance]
+    recipe = plone.recipe.zope2instance
+    environment-vars =
+        FASTEMBED_CACHE_PATH ${buildout:directory}/var/fastembed_cache
+
+Or in a shell startup script / ``.env`` file::
+
+    export FASTEMBED_CACHE_PATH=/var/plone/fastembed_cache
+
+**Important:** Some environments (e.g., Docker with tmpfs) may default the cache to
+``/tmp``, which is cleared on reboot. Setting ``FASTEMBED_CACHE_PATH`` to a persistent
+directory prevents model files from being lost after a restart.
+
+On startup, the package first attempts to load models from the local cache without
+network access. If the local cache is unavailable, it falls back to downloading from
+HuggingFace Hub. This means that once models are downloaded, the system works fully
+offline.
+
 Offline Model Download
 ~~~~~~~~~~~~~~~~~~~~~~
 
-FastEmbed downloads models on first use. For offline environments, pre-download
-models using the CLI command::
+FastEmbed downloads models on first use. For offline or production environments,
+pre-download models to the cache directory using the CLI command::
 
+    # Set cache directory first (optional, defaults to ~/.cache/fastembed)
+    export FASTEMBED_CACHE_PATH=/var/plone/fastembed_cache
+
+    # Download all supported models to the cache directory
     vectorsearch-download
-
-This downloads all supported models to ``~/.cache/fastembed``.
-Set ``FASTEMBED_CACHE_PATH`` environment variable to use a different location.
 
 
 Important Notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "collective.vectorsearch"
-version = "1.0a4"
+version = "1.0a5"
 description = "LLM vector search on Plone"
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/src/collective/vectorsearch/embedding.py
+++ b/src/collective/vectorsearch/embedding.py
@@ -41,7 +41,13 @@ class FastEmbedEmbedding(EmbeddingBase):
     meta_type = "FastEmbedEmbedding"
 
     def __init__(
-        self, model_name, chunk_size=500, prefix_query=None, prefix_passage=None
+        self,
+        model_name,
+        chunk_size=500,
+        prefix_query=None,
+        prefix_passage=None,
+        cache_dir=None,
+        local_files_only=False,
     ):
         """
         Initialize FastEmbed embedding.
@@ -51,6 +57,9 @@ class FastEmbedEmbedding(EmbeddingBase):
             chunk_size: Maximum text length for chunking
             prefix_query: Prefix to add to query text
             prefix_passage: Prefix to add to passage/document text
+            cache_dir: Directory for model file cache (None uses FastEmbed default)
+            local_files_only: If True, only use locally cached models without
+                network access
         """
         try:
             from fastembed import TextEmbedding
@@ -59,7 +68,13 @@ class FastEmbedEmbedding(EmbeddingBase):
                 "FastEmbed library not installed. Install with: pip install fastembed"
             ) from err
 
-        self.model = TextEmbedding(model_name=model_name)
+        kwargs = {}
+        if cache_dir is not None:
+            kwargs["cache_dir"] = str(cache_dir)
+        if local_files_only:
+            kwargs["local_files_only"] = True
+
+        self.model = TextEmbedding(model_name=model_name, **kwargs)
         self.chunk_size = chunk_size
         self.prefix_query = prefix_query
         self.prefix_passage = prefix_passage

--- a/src/collective/vectorsearch/model_providers.py
+++ b/src/collective/vectorsearch/model_providers.py
@@ -183,13 +183,36 @@ class BaseEmbeddingModelProvider:
             )
 
         elif self.embedding_class == "FastEmbedEmbedding":
-            # FastEmbed doesn't use ModelCache (has its own caching)
-            return EmbeddingClass(
-                self.model_name,
-                chunk_size=chunk_size,
-                prefix_query=prefix_query,
-                prefix_passage=prefix_passage,
-            )
+            cache_dir = None
+            if self.use_cache_dir:
+                from collective.vectorsearch.offline import get_cache_dir
+
+                cache_dir = get_cache_dir()
+
+            # Try local-only first to avoid network requests on startup
+            # (same pattern as ModelCache.get_model for SentenceTransformer)
+            try:
+                return EmbeddingClass(
+                    self.model_name,
+                    chunk_size=chunk_size,
+                    prefix_query=prefix_query,
+                    prefix_passage=prefix_passage,
+                    cache_dir=cache_dir,
+                    local_files_only=True,
+                )
+            except Exception:
+                logger.info(
+                    "FastEmbed model '%s' local load failed, "
+                    "trying with network access...",
+                    self.model_name,
+                )
+                return EmbeddingClass(
+                    self.model_name,
+                    chunk_size=chunk_size,
+                    prefix_query=prefix_query,
+                    prefix_passage=prefix_passage,
+                    cache_dir=cache_dir,
+                )
 
         else:
             raise ValueError(f"Unknown embedding_class: {self.embedding_class}")

--- a/src/collective/vectorsearch/offline.py
+++ b/src/collective/vectorsearch/offline.py
@@ -55,10 +55,11 @@ def _register_custom_model_if_needed(model_name: str) -> None:
     """
     for model_info in SUPPORTED_MODELS:
         if model_info["name"] == model_name and model_info.get("custom_registration"):
+            from fastembed.common.model_description import PoolingType
+
             from collective.vectorsearch.model_providers import (
                 _register_fastembed_custom_model,
             )
-            from fastembed.common.model_description import PoolingType
 
             reg = model_info["custom_registration"]
             pooling_map = {"mean": PoolingType.MEAN, "cls": PoolingType.CLS}
@@ -110,6 +111,10 @@ def download_model(model_name: str, cache_dir: Optional[Path] = None) -> Path:
 
     cache_dir = cache_dir or get_cache_dir()
     os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
+
+    # Register custom model if needed (e.g., intfloat/multilingual-e5-base
+    # is not in FastEmbed's built-in supported list)
+    _register_custom_model_if_needed(model_name)
 
     logger.info(f"Downloading model {model_name} to {cache_dir}")
     print(f"Downloading: {model_name}")

--- a/src/collective/vectorsearch/offline.py
+++ b/src/collective/vectorsearch/offline.py
@@ -30,13 +30,47 @@ SUPPORTED_MODELS = [
         "name": "sentence-transformers/all-MiniLM-L6-v2",
         "description": "MiniLM L6 v2 - lightweight English model (~90 MB)",
         "provider_id": "all-minilm-l6",
+        "custom_registration": None,
     },
     {
         "name": "intfloat/multilingual-e5-base",
         "description": "E5 Base Multilingual - 100+ languages (~1.1 GB)",
         "provider_id": "e5-base-multilingual",
+        "custom_registration": {
+            "dim": 768,
+            "pooling": "mean",
+            "normalization": True,
+            "model_file": "onnx/model.onnx",
+            "additional_files": ["sentencepiece.bpe.model"],
+        },
     },
 ]
+
+
+def _register_custom_model_if_needed(model_name: str) -> None:
+    """Register a custom model with FastEmbed if it requires custom registration.
+
+    Looks up the model in SUPPORTED_MODELS and, if it has custom_registration
+    config, delegates to model_providers._register_fastembed_custom_model().
+    """
+    for model_info in SUPPORTED_MODELS:
+        if model_info["name"] == model_name and model_info.get("custom_registration"):
+            from collective.vectorsearch.model_providers import (
+                _register_fastembed_custom_model,
+            )
+            from fastembed.common.model_description import PoolingType
+
+            reg = model_info["custom_registration"]
+            pooling_map = {"mean": PoolingType.MEAN, "cls": PoolingType.CLS}
+            _register_fastembed_custom_model(
+                model_name=model_name,
+                dim=reg["dim"],
+                pooling=pooling_map[reg["pooling"]],
+                normalization=reg["normalization"],
+                model_file=reg["model_file"],
+                additional_files=reg.get("additional_files"),
+            )
+            return
 
 
 def get_cache_dir() -> Path:


### PR DESCRIPTION
## Summary

- Pass `cache_dir` and `local_files_only` parameters from model providers
  through `FastEmbedEmbedding` to FastEmbed's `TextEmbedding`
- Try local cache first (`local_files_only=True`), fall back to network
  download (same pattern as `ModelCache.get_model()` for SentenceTransformers)
- Activate the previously unused `use_cache_dir` provider attribute
- Document `FASTEMBED_CACHE_PATH` configuration in both READMEs

## Files changed

- `embedding.py` — Add `cache_dir` and `local_files_only` params
- `model_providers.py` — Use `get_cache_dir()` when `use_cache_dir=True`,
  add local-first fallback
- `README.rst` / `README-ja.rst` — Add cache directory documentation
- `CHANGES.rst` — Add 1.0a5 changelog entry
- `pyproject.toml` — Bump version to 1.0a5